### PR TITLE
Fixed install node step failing without path to extension-repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,8 +68,9 @@ jobs:
       - name: Install Node and NPM
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ fromJson(steps.package_json.outputs.volta).node }}
           cache: npm
+          cache-dependency-path: extension-repo/package-lock.json
+          node-version: ${{ fromJson(steps.package_json.outputs.volta).node }}
 
       - name: Install packages and build
         run: |


### PR DESCRIPTION
Testing here first; will move to `paranext-extension-template` once I know it works.